### PR TITLE
case xterm-256color-italic

### DIFF
--- a/functions/ssh.fish
+++ b/functions/ssh.fish
@@ -13,7 +13,7 @@ function ssh -d "OpenSSH SSH client (remote login program) with a conservative $
     case screen-256color
       set -lx TERM screen
       command ssh $argv
-    case xterm-256color xterm-termite
+    case xterm-256color xterm-termite xterm-256color-italic
       set -lx TERM xterm
       command ssh $argv
     case tmux-256color


### PR DESCRIPTION
I'm using tmux in iterm2 with `xterm-256color-italic` configured, so I added a `case` to support this.
